### PR TITLE
Add section header component

### DIFF
--- a/components/section-header/index.js
+++ b/components/section-header/index.js
@@ -1,0 +1,35 @@
+import styles from './style.css'
+import marked from 'marked'
+
+export default function SectionHeader({ headline, description, use_h1 }) {
+  return (
+    <div className="g-section-header">
+      {headline &&
+        (use_h1 ? (
+          <h1
+            dangerouslySetInnerHTML={{
+              __html: marked.inlineLexer(headline, [])
+            }}
+            className="g-type-display-1"
+          />
+        ) : (
+          <h2
+            dangerouslySetInnerHTML={{
+              __html: marked.inlineLexer(headline, [])
+            }}
+            className="g-type-section-1"
+          />
+        ))}
+
+      {description && (
+        <h3
+          dangerouslySetInnerHTML={{
+            __html: marked.inlineLexer(description, [])
+          }}
+          className="g-type-intro"
+        />
+      )}
+      <style jsx>{styles}</style>
+    </div>
+  )
+}

--- a/components/section-header/style.css
+++ b/components/section-header/style.css
@@ -1,0 +1,17 @@
+.g-section-header {
+  text-align: center;
+  max-width: 784px;
+  margin: 0 auto 100px auto;
+
+  & h1 {
+    margin: 0;
+  }
+
+  & h2 {
+    margin: 0;
+  }
+
+  & h3 {
+    margin: 1.333333em 0 0 0;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3560,6 +3560,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "marked": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.5.1.tgz",
+      "integrity": "sha512-iUkBZegCZou4AdwbKTwSW/lNDcz5OuRSl3qdcl31Ia0B2QPG0Jn+tKblh/9/eP9/6+4h27vpoh8wel/vQOV0vw=="
+    },
     "maximatch": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "babel-loader": "^8.0.4",
+    "marked": "0.5.1",
     "next": "^7.0.2",
     "postcss-preset-env": "^6.2.0",
     "react": "^16.6.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import globalBase from '../components/global-styles/base.global.css'
 import typeBase from '../components/global-styles/typography.global.css'
 import codeHighlightBase from '../components/global-styles/code-highlighting.global.css'
 import Button from '../components/button'
+import SectionHeader from '../components/section-header'
 
 const Index = () => (
   <div>
@@ -24,6 +25,10 @@ const Index = () => (
         <h6>Button</h6>
         <Button title="Testing" url="#" theme="dark-outline" />
       </li>
+      <li>
+        <h6>Section header</h6>
+        <SectionHeader headline="This is a headline" description="now for a really long description of some text that you might never read" use_h1={true} />
+        </li>
     </ul>
   </div>
 )


### PR DESCRIPTION
Adds our section header component.

`@extend` stuff won't work until global styles are sorted.