### PR TITLE
Moved over the code block component

### DIFF
--- a/components/code-block/index.tsx
+++ b/components/code-block/index.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+
+import tippy from 'tippy.js/dist/tippy.js'
+
+import './style.css'
+
+import { CodeBlockProps, CodeBlockState } from './types'
+
+export default class CodeBlock extends React.Component<
+  CodeBlockProps,
+  CodeBlockState
+> {
+
+  constructor(props: CodeBlockProps) {
+    super(props)
+    this.state = {
+      tooltip: 'Copy to Clipboard'
+    }
+
+    this.copyToClipboard = this.copyToClipboard.bind(this);
+  }
+
+  public componentDidMount() {
+    tippy('.g-tooltip', {
+      animation: 'fade',
+      arrow: true,
+      distance: 10,
+      placement: 'top',
+      hideOnClick: false,
+      size: 'small'
+    })
+  }
+
+  public copyToClipboard() {
+    // we could use the newer clipboard API... but it's
+    // still fairly new, so legacy support FTW!
+    const el = document.createElement('textarea')
+    el.value = this.props.code
+    document.body.appendChild(el)
+    el.select()
+    try {
+      document.execCommand('copy')
+      this.setState({ tooltip: 'Copied!' })
+    } catch (ex) {
+      this.setState({ tooltip: 'Failed to Copy' })
+    }
+
+    document.body.removeChild(el)
+    setTimeout(() => this.setState({ tooltip: 'Copy to Clipboard' }), 3000)
+  }
+
+  public render() {
+
+    return (
+      <code
+        className={`g-code-block${
+          this.props.prefix ? ' ' + this.props.prefix : ''
+        }`}
+      >
+        <ol className={this.props.prefix}>
+          {this.props.code.split('\n').map((l, i) => (
+            <li key={`line-${i}`}>{l}</li>
+          ))}
+        </ol>
+        <span
+          className="g-tooltip"
+          data-tippy-content={this.state.tooltip}
+          onClick={this.copyToClipboard}
+        />
+      </code>
+    );
+  }
+}

--- a/components/code-block/style.css
+++ b/components/code-block/style.css
@@ -1,0 +1,87 @@
+.g-code-block {
+    position: relative;
+    border-radius: 4px;
+    word-break: break-all;
+    word-wrap: break-word;
+    font-size: 0.8em;
+    display: block;
+    line-height: 1.6em;
+    background: #191f28;
+    padding: 6px 10px;
+    margin: 6px 10px;
+    color: white;
+    white-space: pre-wrap;
+  
+    & > ol {
+      display: table;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+  
+      & > li {
+        display: table-row;
+        counter-increment: table-ol;
+        vertical-align: middle;
+        white-space: nowrap;
+  
+        &:before {
+          display: table-cell;
+          padding-right: 7px;
+          text-align: right;
+          color: teal;
+        }
+      }
+  
+      &.numbered {
+        & > li:before {
+          content: counter(table-ol);
+        }
+      }
+  
+      &.dollar {
+        & > li:before {
+          content: '$';
+        }
+      }
+  
+      &.terminal {
+        & > li:before {
+          content: '>';
+        }
+      }
+    }
+  
+    &:hover {
+      & span {
+        opacity: 1;
+      }
+    }
+  
+    & > span {
+      background-image: url('/img/clipboard.svg');
+      background-color: white;
+      background-size: 14px 15px;
+      border-radius: 4px;
+      background-position: center center;
+      background-repeat: no-repeat;
+  
+      width: 25px;
+      height: 25px;
+      display: block;
+      position: absolute;
+      top: 3px;
+      right: 4px;
+      cursor: pointer;
+      border-radius: 4px;
+  
+      transition: opacity 0.3s ease-in-out;
+      opacity: 0;
+  
+      &:hover {
+        background-color: #aaaaaa;
+      }
+      &:active {
+        top: 4px;
+      }
+    }
+  }

--- a/components/code-block/types.d.ts
+++ b/components/code-block/types.d.ts
@@ -1,0 +1,13 @@
+export interface CodeBlockProps {
+    prefix: Prefix,
+    code: string
+}
+
+type Prefix =
+  | 'numbered'
+  | 'dollar'
+  | 'terminal'
+  
+export interface CodeBlockState {
+    tooltip: string
+}

--- a/components/global-styles/playground.css
+++ b/components/global-styles/playground.css
@@ -1,3 +1,8 @@
 ul {
   list-style: none;
+  padding-right: 40px;
+}
+
+.top-buffer {
+  margin-top: 40px;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5953,6 +5953,11 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "popper.js": {
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.6.tgz",
+      "integrity": "sha512-AGwHGQBKumlk/MDfrSOf0JHhJCImdDMcGNoqKmKkU+68GFazv3CQ6q9r7Ja1sKDZmYWTckY/uLyEznheTDycnA=="
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -8397,6 +8402,14 @@
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "requires": {
         "setimmediate": "^1.0.4"
+      }
+    },
+    "tippy.js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-3.4.0.tgz",
+      "integrity": "sha512-mI5Fyn/E/nXRrGQKk/5M6baw9hcc6h3I11zMe5YR2LYitwmymGw9n+J3BstdOXcqx15+p0EFv3DpwSHNhePl3A==",
+      "requires": {
+        "popper.js": "^1.14.6"
       }
     },
     "title-case": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-apollo": "^2.3.2",
     "react-dom": "^16.6.0",
     "slugify": "^1.3.2",
-    "stringify-object": "^3.3.0"
+    "stringify-object": "^3.3.0",
+    "tippy.js": "^3.4.0"
   },
   "devDependencies": {
     "@hashicorp/tsconfig": "^1.0.2",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import '../components/global-styles/playground.css'
 
 import Button from '../components/button'
+import CodeBlock from '../components/code-block'
 import SectionHeader from '../components/section-header'
 import Toggle from '../components/toggle'
 import Image from '../components/image'
@@ -59,6 +60,21 @@ const Index = () => (
       <li>
         <h6>Vertical Text Block List</h6>
         <VerticalTextBlockList data={VerticalTextBlockListData} />
+      </li>
+      <li>
+        <h6>Code Block</h6>
+        <div className='top-buffer'>
+          <CodeBlock prefix='terminal' code='Here is the code block render with terminal prefix' />
+        </div>
+        <div className='top-buffer'>
+          <CodeBlock prefix='dollar' code='Here is the code block render with dollar prefix' />
+        </div>
+        <div className='top-buffer'>
+          <CodeBlock prefix='numbered' code='Here is the code block render with numbered prefix' />
+        </div>
+        <div className='top-buffer'>
+          <CodeBlock code='Here is the code block render with no prefix' />
+        </div>
       </li>
     </ul>
 

--- a/types/tippy.d.ts
+++ b/types/tippy.d.ts
@@ -1,0 +1,1 @@
+declare module 'tippy.js/dist/tippy.js'


### PR DESCRIPTION
This PR has the code block component being added. 

This is my first TypeScript coding so I may have missed something. Take a look over the changes and provide me with any feedback.

I updated the playground css file to give a little more padding on the right side of the screen as the "Copy to Clipboard" text was not completely fitting. I also added a top-buffer class that can be used when needing some top margin. This helped the different code blocks display nicer.

