### PR TITLE
Plugin Abstraction

### DIFF
--- a/lib/apolloClient.js
+++ b/lib/apolloClient.js
@@ -9,7 +9,6 @@ if (!process.browser) {
 }
 
 function create(initialState) {
-  // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
   return new ApolloClient({
     connectToDevTools: process.browser,
     ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)

--- a/lib/dato-client.js
+++ b/lib/dato-client.js
@@ -1,0 +1,22 @@
+const getClient = require('./apolloClient')
+
+// A very light wrapper over Dato graphql queries. I'd like for this to be
+// expanded in time.
+module.exports = class DatoClient {
+  constructor(apiKey) {
+    // TODO: I would like for the apollo client to be able to accept different
+    // credentials so that this getClient function can be initialized
+    // separately for different services, but that's a little out of depth at
+    // the moment.
+    this.client = getClient()
+  }
+
+  load(query) {
+    return this.client
+      .query({ query })
+      .catch(err => {
+        console.warn(`Error loading from Dato`, err)
+      })
+      .then(resp => resp.data)
+  }
+}

--- a/lib/mdx-layout-loader.js
+++ b/lib/mdx-layout-loader.js
@@ -9,7 +9,7 @@ const stringifyObject = require('stringify-object')
 module.exports = function(src) {
   const { content, data } = matter(src)
 
-  // todo: make layout optional, add good error message for incorrect layout path
+  // TODO: make layout optional, add good error message for incorrect layout path
   return `import layout from '${path.resolve(
     __dirname,
     '../pages/layouts',

--- a/lib/next-plugin-bundle-analyzer.js
+++ b/lib/next-plugin-bundle-analyzer.js
@@ -1,0 +1,29 @@
+const bundleAnalyzer = require('@zeit/next-bundle-analyzer')
+
+// This is just a small wrapper to make the configuration for the bundle
+// analyzer plugin much more sane. In the readme for this plugin, it advises
+// adding the plugin itself, then copy-pasting the config seen below into your
+// next.js config. The best approach here would be to dig in to which of the
+// options might realistically be changed by users, and convert this from an
+// option-less plugin to a plugin with options, then automatically add the
+// properties below to avoid copy-pasting and extra boilerplate for the user.
+// Someday, I'd like to pull request this change to the original plugin, but
+// for now this will do.
+module.exports = function bundleAnalyzerPlugin(config) {
+  config.analyzeServer = ['server', 'both'].includes(process.env.BUNDLE_ANALYZE)
+  config.analyzeBrowser = ['browser', 'both'].includes(
+    process.env.BUNDLE_ANALYZE
+  )
+  config.bundleAnalyzerConfig = {
+    server: {
+      analyzerMode: 'static',
+      reportFilename: '../../bundles/server.html'
+    },
+    browser: {
+      analyzerMode: 'static',
+      reportFilename: '../bundles/client.html'
+    }
+  }
+
+  return bundleAnalyzer(config)
+}

--- a/lib/next-plugin-hashicorp.js
+++ b/lib/next-plugin-hashicorp.js
@@ -1,0 +1,28 @@
+const path = require('path')
+
+// TODO: Write a little readme for this plugin
+module.exports = function hashicorpPlugin(pluginOptions = {}) {
+  return function hashicorpPluginInternal(nextConfig = {}) {
+    return Object.assign({}, nextConfig, {
+      pageExtensions: ['js', 'jsx', 'tsx', 'mdx'],
+      webpack(config, options) {
+        config.module.rules.push({
+          test: /\.mdx$/,
+          use: [
+            options.defaultLoaders.babel,
+            '@mdx-js/loader',
+            // This will resolve from this current file's location, so we should
+            // be able to always bundle these together and resolve accurately.
+            path.join(__dirname, 'mdx-layout-loader')
+          ]
+        })
+
+        if (typeof nextConfig.webpack === 'function') {
+          return nextConfig.webpack(config, options)
+        }
+
+        return config
+      }
+    })
+  }
+}

--- a/lib/next-plugin-template.js
+++ b/lib/next-plugin-template.js
@@ -1,0 +1,39 @@
+// Next.js Plugin Template
+// -----------------------
+//
+// Next.js plugins can take one of two forms, based on official provided
+// examples. The form here is for a plugin that accepts options. It is exposed
+// as a function that returns a function, so it is executed as such:
+//
+// examplePlugin({ foo: 'bar' })(config)
+//
+// However, there are also nextjs plugins which accept no options, and those at
+// the moment expose a different format, just returning the internal function.
+// Plugins that have no options look like this:
+//
+// examplePlugin(config)
+//
+// Personally, I think this is not a great pattern -- it would be better to
+// have all plugins have the capacity to take options, but if they have none,
+// just call without arguments as such:
+//
+// examplePlugin()(config)
+//
+// But this is now how the nextjs authors have chosen to do things. I would
+// propose that within HashiCorp, our plugins should follow the last pattern --
+// always allowing for options whether or not they currently take them.
+//
+// I should also note that official next.js plugins typically nest two arrow
+// functions, whereas I have adopted the pattern of nesting two named
+// functions. While this is the more verbose approach, named functions have a
+// great amount of additional utility when debugging, which is why I have moved
+// toward this pattern. Imo, clarity and debugging ease trumps terse-ness just
+// about always.
+
+module.exports = function examplePlugin(pluginOptions = {}) {
+  return function examplePluginInternal(nextConfig = {}) {
+    return Object.assign({}, nextConfig, {
+      // config you wish to add in goes here
+    })
+  }
+}

--- a/lib/next-plugins.js
+++ b/lib/next-plugins.js
@@ -1,0 +1,16 @@
+// exposes a slightly more sane pattern for extending next's config with plugins
+module.exports = function nextPlugins(plugins, config) {
+  let result = config
+  plugins.reverse().map(plugin => {
+    if (Array.isArray(plugin)) {
+      result = plugin[0](result, options)
+    } else if (typeof plugin === 'function') {
+      result = plugin(result)
+    } else {
+      throw new Error(
+        'Plugins can be a function, or an array containing a function and its config arguments.'
+      )
+    }
+  })
+  return result
+}

--- a/lib/next-plugins.js
+++ b/lib/next-plugins.js
@@ -1,16 +1,72 @@
-// exposes a slightly more sane pattern for extending next's config with plugins
-module.exports = function nextPlugins(plugins, config) {
-  let result = config
-  plugins.reverse().map(plugin => {
-    if (Array.isArray(plugin)) {
-      result = plugin[0](result, options)
-    } else if (typeof plugin === 'function') {
-      result = plugin(result)
-    } else {
-      throw new Error(
-        'Plugins can be a function, or an array containing a function and its config arguments.'
+// Next Plugins
+// ------------
+// A utility that makes the using next.js plugins a little smoother.
+//
+// Example usage, within next.config.js:
+//
+// ```
+// module.exports = nextPlugins([
+//   somePlugin(),
+//   someOtherPlugin
+// ], {
+//   /* your normal nextjs config here */
+// })
+// ```
+// Note that the order from how plugins are typically used with next.js should
+// be reversed with this pattern. For example, if you were previously using
+// plugins in the following manner:
+//
+// pluginOne(pluginTwo(pluginThree(config)))
+//
+// The order of execution would actually be the opposite of what makes
+// intuitive sense - pluginThree would be the first to run, followed by two,
+// then one, as functions execute from the inside out. If you needed to
+// precisely preserve order, and order does matter for some next.js plugins,
+// you would need to convert the above config as such for use within next
+// plugins:
+//
+// nextPlugins([pluginThree, pluginTwo, pluginOne], config)
+//
+// Just worth keeping in mind as it can be a common mistake to miss this. The
+// good news is that next-plugins' pattern is much easier to read and manage,
+// so post conversion everything should make perfect sense -- plugins are
+// executed in exactly the order they are seen in the array.
+
+module.exports = function nextPlugins(plugins, config = {}) {
+  // For the initial config, extract the webpack function so it is not clobbered
+  // by plugin-added webpack configs
+  let result = extractWebpackModification(config)
+
+  // For each plugin, run it, passing in the config, and extract the webpack
+  // function in the same way so each one can be preserved.
+  plugins.forEach(plugin => {
+    result = extractWebpackModification(plugin(result))
+  })
+
+  // Apply webpack function modifications
+  // TODO: in theory the config mod should be applied last, but currently is
+  // applied first
+  if (webpackModifications.length) {
+    result.webpack = function(config, options) {
+      return webpackModifications.reduce(
+        (acc, mod) => mod(acc, options),
+        config
       )
     }
-  })
+  }
+
+  return result
+}
+
+// Webpack config modifications are exposed as a function, so any plugin that
+// utilizes this will clobber the previous plugin's mods, since functions
+// cannot be merged for obvious reasons. To solve this, we store each webpack
+// config mod function, and return a function that applies each in order.
+const webpackModifications = []
+function extractWebpackModification(result) {
+  if (result.webpack) {
+    webpackModifications.push(result.webpack)
+    delete result.webpack
+  }
   return result
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import App, { Container } from 'next/app'
 import { ApolloProvider } from 'react-apollo'
-import getClient from '../lib/apolloClient'
 import delphi from '../lib/delphi'
 
 import '../components/global-styles/base.global.css'


### PR DESCRIPTION
This PR does two things:

1. Adds a "next-plugins" utility that exposes a more sane pattern for using "next plugins"
2. Abstracts all of our config changes into a plugin, rather than direct modification to the config file

There are a LOT of changes here. I did my best to thoroughly comment everything, but please feel free to call me out in a review if anything is unclear. My intention is to move the plugin logic out of the `lib` folder and into its own repo/npm package so that it is more easily shared between projects.